### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,15 @@
 plinkio
 =========
 
-.. image:: https://pypip.in/version/python-plinkio/badge.png
+.. image:: https://img.shields.io/pypi/v/python-plinkio.svg
     :target: https://pypi.python.org/pypi/python-plinkio/
     :alt: Latest Version
     
-.. image:: https://pypip.in/status/python-plinkio/badge.png
+.. image:: https://img.shields.io/pypi/status/python-plinkio.svg
     :target: https://pypi.python.org/pypi/python-plinkio/
     :alt: Development Status
 
-.. image:: https://pypip.in/license/python-plinkio/badge.png
+.. image:: https://img.shields.io/pypi/l/python-plinkio.svg
     :target: https://pypi.python.org/pypi/python-plinkio/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20python-plinkio))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `python-plinkio`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.